### PR TITLE
Added PowerMock annotations to avoid problems with Java 11 and above.

### DIFF
--- a/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/DescriptionManagementTest.java
+++ b/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/DescriptionManagementTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.streampipes.connect.adapter.AdapterRegistry;
@@ -37,6 +38,7 @@ import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ AdapterRegistry.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class DescriptionManagementTest {
 
 

--- a/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/SourcesManagementTest.java
+++ b/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/SourcesManagementTest.java
@@ -29,6 +29,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.streampipes.connect.adapter.exception.AdapterException;
@@ -42,6 +43,7 @@ import java.util.List;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ WorkerRestClient.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class SourcesManagementTest {
     private final static String ID = "id_1234";
 

--- a/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/UnitMasterManagementTest.java
+++ b/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/UnitMasterManagementTest.java
@@ -27,6 +27,7 @@ import com.github.jqudt.onto.UnitFactory;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -40,6 +41,7 @@ import java.util.List;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ UnitProvider.class, UnitFactory.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class UnitMasterManagementTest {
 
     @Test(expected = AdapterException.class)

--- a/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/WorkerRestClientTest.java
+++ b/streampipes-connect-container-master/src/test/java/org/streampipes/connect/container/master/management/WorkerRestClientTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.streampipes.connect.adapter.exception.AdapterException;
@@ -33,6 +34,7 @@ import org.streampipes.model.connect.adapter.GenericAdapterStreamDescription;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ WorkerRestClient.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class WorkerRestClientTest {
 
     /**

--- a/streampipes-connect-container-worker/src/test/java/org/streampipes/connect/container/worker/management/AdapterWorkerManagementTest.java
+++ b/streampipes-connect-container-worker/src/test/java/org/streampipes/connect/container/worker/management/AdapterWorkerManagementTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.streampipes.connect.RunningAdapterInstances;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ AdapterRegistry.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class AdapterWorkerManagementTest {
 
     @Test

--- a/streampipes-rest/src/test/java/org/streampipes/rest/impl/ConsulConfigTest.java
+++ b/streampipes-rest/src/test/java/org/streampipes/rest/impl/ConsulConfigTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.streampipes.config.model.ConfigItem;
@@ -37,6 +38,7 @@ import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ConsulUtil.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class ConsulConfigTest {
 
     @Test


### PR DESCRIPTION
When building with Java 12 I encountered test-failures. A little research pointed out this is a problem of PowerMock which isn't compatible with Java 11 and above. There are options to avoid these problems. One is to add annotations (As I did in this PR) the other is to create a file on the classpath: org/powermock/extensions/configuration.properties with the following content:

`powermock.global-ignore=com.sun.org.apache.xerces.*,javax.xml.*,org.xml.*,javax.management.*`

Unfortunately there is no globally used "test-utils" module and therefore I used the Annotations.